### PR TITLE
Replaces URLResponseTime with URLFetch in Services/LPM.wl

### DIFF
--- a/.defaultpackages
+++ b/.defaultpackages
@@ -1,4 +1,4 @@
-<|"wljs-editor" -> <|"name" -> "wljs-editor", "version" -> "0.4.9", 
+<|"wljs-editor" -> <|"name" -> "wljs-editor", "version" -> "0.5.0", 
    "description" -> "WLJS Code editor", 
    "scripts" -> <|"build" -> "node --max-old-space-size=8192 \
 ./node_modules/.bin/rollup --config rollup.config.mjs", 
@@ -25,7 +25,7 @@ https://github.com/JerryI/wljs-editor && mv wljs-editor/.git ../.git && cd .. \
    "resolutions" -> <|"@babel/preset-env" -> "7.13.8"|>, "enabled" -> True, 
    "path" -> "wljs-editor", "defaultPackage" -> True|>, 
  "wljs-graphics3d-threejs" -> <|"name" -> "wljs-graphics3d-threejs", 
-   "version" -> "0.2.8", "description" -> 
+   "version" -> "0.3.1", "description" -> 
     "A ThreeJS implementation of Mathematica's Graphics3D", 
    "scripts" -> <|"start" -> "cd example && parcel serve ./*.html --dist-dir \
 ./dev-bundle/ --no-cache --no-hmr", "build-examples" -> "cd example && parcel \
@@ -61,14 +61,13 @@ Mathematica-ThreeJS-graphics-engine/.git ../.git && cd .. && rm -rf _temp"|>,
      "process" -> "^0.11.10", "puppeteer" -> "^15.4.0", 
      "rollup" -> "^2.70.0", "rollup-plugin-combine" -> "^2.1.1", 
      "rollup-plugin-livereload" -> "^2.0.5", "rollup-plugin-serve" -> 
-      "^2.0.2", "simple-git" -> "^3.10.0", "three" -> "^0.148.0", 
-     "yargs" -> "^17.5.1"|>, "dependencies" -> <|"dat.gui" -> "^0.7.9", 
-     "node-sass" -> "^9.0.0", "three-gpu-pathtracer" -> "^0.0.16", 
-     "three-mesh-bvh" -> "^0.6.8"|>, "enabled" -> True, 
-   "path" -> "wljs-graphics3d-threejs", "peerDependencies" -> 
-    <|"three" -> ">=0.139.2", "xatlas-web" -> "^0.1.0"|>, 
-   "defaultPackage" -> True|>, "wljs-graphics-d3" -> 
-  <|"name" -> "wljs-graphics-d3", "version" -> "0.5.8", 
+      "^2.0.2", "simple-git" -> "^3.10.0", "yargs" -> "^17.5.1"|>, 
+   "dependencies" -> <|"dat.gui" -> "^0.7.9", "node-sass" -> "^9.0.0", 
+     "three-gpu-pathtracer" -> "^0.0.16", "three-mesh-bvh" -> "^0.6.8"|>, 
+   "enabled" -> True, "path" -> "wljs-graphics3d-threejs", 
+   "peerDependencies" -> <|"three" -> ">=0.139.2", 
+     "xatlas-web" -> "^0.1.0"|>, "defaultPackage" -> True|>, 
+ "wljs-graphics-d3" -> <|"name" -> "wljs-graphics-d3", "version" -> "0.6.1", 
    "description" -> "D3 implementation of Mathematica's Graphics", 
    "scripts" -> <|"build" -> "node --max-old-space-size=8192 \
 ./node_modules/.bin/rollup --config rollup.config.mjs", 
@@ -128,7 +127,7 @@ cd .. && rm -rf _temp"|>, "wljs-meta" -> <|"jsmodule" -> "dist/kernel.js",
      "rollup-plugin-combine" -> "^2.1.1", "serve-static" -> "^1.14.1", 
      "systemjs" -> "^6.14.1"|>, "enabled" -> True, "path" -> "wljs-inputs", 
    "defaultPackage" -> True|>, "wljs-interpreter" -> 
-  <|"name" -> "wljs-interpreter", "version" -> "0.4.1", 
+  <|"name" -> "wljs-interpreter", "version" -> "0.4.2", 
    "description" -> "A core library and WL interpreter written in pure JS", 
    "scripts" -> <|"start" -> "parcel index.html --open", 
      "build" -> "parcel build index.html --public-url ./", 

--- a/Examples/02 - Dynamics/CurvesFit.wln
+++ b/Examples/02 - Dynamics/CurvesFit.wln
@@ -1,4 +1,4 @@
-<|"notebook" -> <|"name" -> "Assistant", "id" -> "creamer-ca1dd", 
+<|"notebook" -> <|"name" -> "Assistant", "id" -> "cession-183e7", 
    "kernel" -> LocalKernel, "objects" -> 
     <|"58cca417-f8bd-440b-a396-79a52a2fc989" -> 
       <|"json" -> "[\"Graphics\",[\"List\",[\"RGBColor\",1,0.95,0.9],[\"Event\
@@ -22,10 +22,11 @@ ne\",[\"Hold\",\"fit\"]]],[\"Rule\",\"PlotRange\",[\"List\",[\"List\",-1,1],[\
       <|"json" -> "[\"EditorView\",[\"Offload\",\"equation\"]]", 
        "date" -> DateObject[{2023, 11, 5, 22, 40, 
           53.833011`8.48362364625509}, "Instant", "Gregorian", 1.]|>|>, 
-   "path" -> "/Volumes/Data/Github/wolfram-js-frontend/Examples/Dynamics/Basi\
-c/CurvesFit.wln", "cell" :> Exit[], 
-   "date" -> DateObject[{2023, 11, 5, 22, 40, 31.829163`8.255400198990683}, 
-     "Instant", "Gregorian", 1.], "channel" -> WebSocketChannel[
+   "path" -> 
+    "/home/bp38/git/wolfram-js-frontend/Examples/02 - Dynamics/CurvesFit.wln"\
+, "cell" :> Exit[], "date" -> DateObject[{2024, 1, 19, 17, 45, 
+      19.574684`8.044269743818024}, "Instant", "Gregorian", 0.], 
+   "channel" -> WebSocketChannel[
      KirillBelov`WebSocketHandler`WebSocketChannel`$43], 
    "symbols" -> <|"points" -> <|"date" -> DateObject[{2023, 11, 5, 22, 40, 
           51.605927`8.465274558961482}, "Instant", "Gregorian", 1.]|>, 
@@ -34,15 +35,15 @@ c/CurvesFit.wln", "cell" :> Exit[],
      "equation" -> <|"date" -> DateObject[{2023, 11, 5, 22, 40, 
           53.858337`8.483827914145792}, "Instant", "Gregorian", 1.]|>|>, 
    "SelectedCell" -> "df81c674-082a-4a7b-b521-9e71d081270bbb9fc7a79"|>, 
- "cells" -> {<|"id" -> "adeeed92-296a-42e7-a8b6-ea7a02c73bacbb9fc7a79", 
+ "cells" -> {<|"id" -> "adeeed92-296a-42e7-a8b6-ea7a02c73bacbb9fc7a79467", 
     "type" -> "input", "data" -> ".md\n# Fitting curves\nexample", 
-    "display" -> "codemirror", "sign" -> "creamer-ca1dd", 
+    "display" -> "codemirror", "sign" -> "cession-183e7", 
     "props" -> <|"hidden" -> True|>|>, 
-   <|"id" -> "756e9769-2a32-4b3e-8490-114988ca62dabb9fc7a79", 
+   <|"id" -> "756e9769-2a32-4b3e-8490-114988ca62dabb9fc7a79467", 
     "type" -> "output", "data" -> "\n# Fitting curves\nexample", 
-    "display" -> "markdown", "sign" -> "creamer-ca1dd", 
+    "display" -> "markdown", "sign" -> "cession-183e7", 
     "props" -> <|"hidden" -> False|>|>, 
-   <|"id" -> "df81c674-082a-4a7b-b521-9e71d081270bbb9fc7a79", 
+   <|"id" -> "df81c674-082a-4a7b-b521-9e71d081270bbb9fc7a79467", 
     "type" -> "input", "data" -> "fit = {};\npoints = {};\norder = \
 1;\nequation = \"\";\n\nlineFit[points_] := With[{o = \
 Table[(*SpB[*)Power[x(*|*),(*|*)i](*]SpB*), {i, 0, order}]},\n  With[{f = \
@@ -52,12 +53,12 @@ RGBColor[1,0.95,0.9],\n  EventHandler[Rectangle[{-10,-10}, {10,10}], \
 {\"click\"->Function[xy, \n    points = Append[points, xy]; \n    fit = \
 lineFit[points]\n  ]}],\n  PointSize[0.1],\n  Red, Point[points//Hold], Cyan, \
 Line[fit//Hold]\n}, PlotRange->{{-1,1}, {-1,1}}]", "display" -> "codemirror", 
-    "sign" -> "creamer-ca1dd", "props" -> <|"hidden" -> False, 
+    "sign" -> "cession-183e7", "props" -> <|"hidden" -> False, 
       "init" -> True|>|>, 
-   <|"id" -> "dd22b1c5-fe23-45b4-b9e2-b5d9f569152ebb9fc7a79", 
+   <|"id" -> "dd22b1c5-fe23-45b4-b9e2-b5d9f569152ebb9fc7a79467", 
     "type" -> "input", "data" -> "Function[data, points = {}; fit = {};] // \
 InputButton[\"Clear\"]\nFunction[data, order = data; fit = lineFit[points]] \
 // InputRange[1, 5, 1]\nEditorView[equation // Offload] // \
-CreateFrontEndObject", "display" -> "codemirror", "sign" -> "creamer-ca1dd", 
+CreateFrontEndObject", "display" -> "codemirror", "sign" -> "cession-183e7", 
     "props" -> <|"hidden" -> False, "init" -> True|>|>}, 
  "serializer" -> "jsfn3"|>

--- a/Services/LPM.wl
+++ b/Services/LPM.wl
@@ -65,7 +65,7 @@ PacletRepositories[list_List, OptionsPattern[]] := Module[{projectDir, info, rep
       Return[Null, Module];
     ];
 
-    If[FailureQ[ URLResponseTime["https://github.com"] ],
+    If[FailureQ[ URLFetch["https://github.com"] ],
       Echo["LPM >> PASSIVE MODE. Github is not available"];
       Map[pacletDirectoryLoad] @  Map[DirectoryName] @  FileNames["PacletInfo.wl", {#}, {2}]& @ FileNameJoin[{projectDir, "wl_packages"}];
       Return[Null, Module];  
@@ -78,7 +78,7 @@ PacletRepositories[list_List, OptionsPattern[]] := Module[{projectDir, info, rep
     Echo["LPM >> checking cached"];
     cache = CacheLoad[projectDir];
 
-    If[FailureQ[ URLResponseTime["https://github.com"] ] ,
+    If[FailureQ[ URLFetch["https://github.com"] ] ,
       Echo["LPM >> ERROR! no internet connection to github.com!"];
       
       If[!MissingQ[cache], 


### PR DESCRIPTION
Changing from `URLResponseTime` to `URLFetch` in `Services/LPM.wl` allows package manager to find and download packages. Previous use of `URLResponseTime` was resulting in not finding packages and reported an issue with SSL CA certificates. When testing in wolframscript this behaviour was persistent, this might be an issue related to wolframscript running on Linux as this solves the issue found in #72 which appears similar to #58 and potentially #71.